### PR TITLE
Update usage of datetime.datetime.utcfromtimestamp(), which is being deprecated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.envrc
+.direnv/

--- a/bm_monitor.py
+++ b/bm_monitor.py
@@ -100,7 +100,7 @@ def construct_message(c):
     out = ""
     duration = c["Stop"] - c["Start"]
     # convert unix time stamp to human readable format
-    time = dt.datetime.utcfromtimestamp(c["Start"]).strftime("%Y/%m/%d %H:%M")
+    time = dt.datetime.fromtimestamp(c["Start"], dt.timezone.utc).strftime("%Y/%m/%d %H:%M")
     # construct text message from various transmission properties
     out += c["SourceCall"] + ' (' + c["SourceName"] + ') was active on '
     out += str(tg) + ' (' + c["DestinationName"] + ') at '


### PR DESCRIPTION
The current usage of datetime.datetime.utcfromtimestamp() results in an error as the function is being deprecated:

```python
bm_monitor.py:103: DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
  time = dt.datetime.utcfromtimestamp(c["Start"]).strftime("%Y/%m/%d %H:%M")
```

The error is due to the use of `datetime.datetime.utcfromtimestamp()`, which is being deprecated in favor of creating timezone-aware objects. To fix the issue, we should use `datetime.fromtimestamp()` with the `timezone.utc` parameter.

Here's the corrected line:

```python
time = dt.datetime.fromtimestamp(c["Start"], dt.timezone.utc).strftime("%Y/%m/%d %H:%M")
```

This ensures that the datetime object is timezone-aware and explicitly in UTC. By replacing the problematic line in the script with this updated version, the deprecation warning will be resolved.